### PR TITLE
Slicer print log: ask once per print in Anycubic Slicer NEXT

### DIFF
--- a/tools/slicer-print-log/3dfp-print-log.ps1
+++ b/tools/slicer-print-log/3dfp-print-log.ps1
@@ -12,13 +12,14 @@ Install (Bambu Studio / OrcaSlicer / PrusaSlicer and other PrusaSlicer forks):
     "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "C:\path\to\3dfp-print-log.ps1"
   Options may go after the script path:
     --no-ask         skip the "Log this print?" dialog and open the browser straight away
+    --base-url URL   send to a different site (dev/staging)
     --dry-run        print the URL instead of opening the browser
     --debug          write argv/env/gcode header to ~\3dfp-print-log-debug.txt
 
 What it does: takes the filament type/vendor/colour and printer from the
 SLIC3R_* environment variables the slicer sets, reads the .gcode header for
 what the slice actually used (grams, which slots, print time), and opens
-your browser at https://3dfilamentprofiles.com/my/print/log with that data in the URL. Sign in there
+your browser at <site>/my/print/log with that data in the URL. Sign in there
 once and pick which spool each filament came from; the site does the actual
 parsing and math. In Bambu Studio it also picks up the real project (3MF)
 name and, on re-slices, the plate.
@@ -33,7 +34,7 @@ break your slicer's export. Works on Windows PowerShell 5.1 and PowerShell 7.
 
 $ErrorActionPreference = "Continue"
 
-$Version = "1.0.0"
+$Version = "1.1.0"
 $DefaultBaseUrl = "https://3dfilamentprofiles.com"
 
 # Kept in sync with 3dfp-print-log.py and the regexes in
@@ -71,6 +72,9 @@ $EnvConfigKeys = @(
 $MaxLineLength = 400
 $MaxPayloadBytes = 16 * 1024
 $DialogTimeoutSeconds = 60
+# Longer than the dialog timeout: a slicer that runs the script again only after the
+# first run's dialog closes still lands inside the window.
+$DedupeWindowSeconds = 120
 
 function Write-Stderr([string] $Message) {
   [Console]::Error.WriteLine("3dfp-print-log: $Message")
@@ -239,6 +243,41 @@ function Build-Url([string] $BaseUrl, [string] $GcodePath) {
   return @(($BaseUrl.TrimEnd("/") + "/my/print/log?$query"), $summary)
 }
 
+function Test-AlreadyHandled([string] $Url) {
+  # True when this exact URL was already handled within $DedupeWindowSeconds. Some slicers
+  # (Anycubic Slicer NEXT) run post-processing scripts several times for one slice; keying
+  # on the URL rather than the gcode path catches that whatever temp file each run is handed.
+  # A marker file per URL in the temp folder, created atomically, lets exactly one run
+  # through even when the runs overlap. Any file-system trouble means "not handled", so the
+  # worst case is the old behaviour: an extra dialog.
+  try {
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $now = Get-Date
+    foreach ($stale in Get-ChildItem -Path $tempDir -Filter "3dfp-print-log-*.seen" -File -ErrorAction SilentlyContinue) {
+      if (($now - $stale.LastWriteTime).TotalSeconds -gt $DedupeWindowSeconds) {
+        Remove-Item -LiteralPath $stale.FullName -Force -ErrorAction SilentlyContinue
+      }
+    }
+    $sha1 = [System.Security.Cryptography.SHA1]::Create()
+    try {
+      $hash = $sha1.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Url))
+    } finally {
+      $sha1.Dispose()
+    }
+    $digest = ([System.BitConverter]::ToString($hash) -replace "-", "").Substring(0, 16).ToLowerInvariant()
+    $marker = Join-Path $tempDir "3dfp-print-log-$digest.seen"
+    try {
+      # CreateNew fails when the file exists, so overlapping runs cannot both win.
+      ([System.IO.File]::Open($marker, [System.IO.FileMode]::CreateNew)).Dispose()
+      return $false
+    } catch {
+      return [System.IO.File]::Exists($marker)
+    }
+  } catch {
+    return $false
+  }
+}
+
 function Confirm-Log([string] $Summary) {
   # Native yes/no dialog with a timeout, no extra assemblies. Timeout or any failure counts
   # as "yes" so an unattended slice still opens a tab instead of silently dropping the print.
@@ -339,6 +378,11 @@ function Main([string[]] $Argv) {
 
   if ($dryRun) {
     [Console]::Out.WriteLine($url)
+    return
+  }
+
+  if (Test-AlreadyHandled $url) {
+    Write-Stderr "this print was already handled a moment ago, skipping."
     return
   }
 

--- a/tools/slicer-print-log/3dfp-print-log.ps1
+++ b/tools/slicer-print-log/3dfp-print-log.ps1
@@ -72,9 +72,9 @@ $EnvConfigKeys = @(
 $MaxLineLength = 400
 $MaxPayloadBytes = 16 * 1024
 $DialogTimeoutSeconds = 60
-# Longer than the dialog timeout: a slicer that runs the script again only after the
-# first run's dialog closes still lands inside the window.
-$DedupeWindowSeconds = 120
+# Measured from the end of the previous run (see Get-ClaimedMarker), so it only has to
+# cover the gap between one run finishing and the slicer starting the next.
+$DedupeWindowSeconds = 10
 
 function Write-Stderr([string] $Message) {
   [Console]::Error.WriteLine("3dfp-print-log: $Message")
@@ -243,13 +243,15 @@ function Build-Url([string] $BaseUrl, [string] $GcodePath) {
   return @(($BaseUrl.TrimEnd("/") + "/my/print/log?$query"), $summary)
 }
 
-function Test-AlreadyHandled([string] $Url) {
-  # True when this exact URL was already handled within $DedupeWindowSeconds. Some slicers
-  # (Anycubic Slicer NEXT) run post-processing scripts several times for one slice; keying
-  # on the URL rather than the gcode path catches that whatever temp file each run is handed.
-  # A marker file per URL in the temp folder, created atomically, lets exactly one run
-  # through even when the runs overlap. Any file-system trouble means "not handled", so the
-  # worst case is the old behaviour: an extra dialog.
+function Get-ClaimedMarker([string] $Url) {
+  # Some slicers (Anycubic Slicer NEXT) run post-processing scripts several times for one
+  # slice. A marker file per URL in the temp folder catches that whatever temp gcode each
+  # run is handed: returns $null when a marker younger than $DedupeWindowSeconds exists,
+  # otherwise the marker path (or "" when the temp folder is unusable, so the worst case is
+  # the old behaviour: an extra dialog). The marker is created atomically, so exactly one of
+  # several overlapping runs wins, and Main refreshes it via Update-Marker when done, so a
+  # slicer that starts the next run only after the first run's dialog closes still lands
+  # inside the window however long that took.
   try {
     $tempDir = [System.IO.Path]::GetTempPath()
     $now = Get-Date
@@ -269,12 +271,22 @@ function Test-AlreadyHandled([string] $Url) {
     try {
       # CreateNew fails when the file exists, so overlapping runs cannot both win.
       ([System.IO.File]::Open($marker, [System.IO.FileMode]::CreateNew)).Dispose()
-      return $false
+      return $marker
     } catch {
-      return [System.IO.File]::Exists($marker)
+      if ([System.IO.File]::Exists($marker)) { return $null }
+      return ""
     }
   } catch {
-    return $false
+    return ""
+  }
+}
+
+function Update-Marker([string] $Marker) {
+  # Restarts the dedupe window from now, once the dialog and browser hand-off are done.
+  if (-not $Marker) { return }
+  try {
+    [System.IO.File]::SetLastWriteTime($Marker, (Get-Date))
+  } catch {
   }
 }
 
@@ -381,17 +393,22 @@ function Main([string[]] $Argv) {
     return
   }
 
-  if (Test-AlreadyHandled $url) {
+  $marker = Get-ClaimedMarker $url
+  if ($null -eq $marker) {
     Write-Stderr "this print was already handled a moment ago, skipping."
     return
   }
 
-  if ($ask -and -not (Confirm-Log $summary)) { return }
-
   try {
-    Start-Process $url
-  } catch {
-    Write-Stderr "could not open browser: $($_.Exception.Message)"
+    if ($ask -and -not (Confirm-Log $summary)) { return }
+
+    try {
+      Start-Process $url
+    } catch {
+      Write-Stderr "could not open browser: $($_.Exception.Message)"
+    }
+  } finally {
+    Update-Marker $marker
   }
 }
 

--- a/tools/slicer-print-log/3dfp-print-log.py
+++ b/tools/slicer-print-log/3dfp-print-log.py
@@ -2,6 +2,7 @@
 """
 3D Filament Profiles - automatic print logging post-processing script.
 https://3dfilamentprofiles.com/help/automatic-print-logging
+Source, README and issues: https://github.com/MarksMakerSpace/filament-profiles/tree/main/tools/slicer-print-log
 
 Install (Bambu Studio / OrcaSlicer / PrusaSlicer and other PrusaSlicer forks):
   Print Settings -> Others -> Post-processing scripts (PrusaSlicer: Print
@@ -18,7 +19,9 @@ so the script asks "Log this print?" first (native dialog, no extra install);
 Skip and nothing happens. Pass --no-ask to always open the browser instead.
 Older Bambu Studio versions only ran them on File -> Export -> Export G-code
 (bambulab/BambuStudio#3006). OrcaSlicer runs them on export; if yours doesn't
-run them on Send, use Export G-code.
+run them on Send, use Export G-code. Anycubic Slicer NEXT runs the script
+several times for one slice, so a slice that builds the same URL as one seen
+in the last DEDUPE_WINDOW_SECONDS is ignored (filament-profiles#644).
 
 What it does: takes the filament type/vendor/colour and printer from the
 SLIC3R_* environment variables the slicer sets, reads the .gcode header for
@@ -45,7 +48,7 @@ import sys
 import webbrowser
 from urllib.parse import quote
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 DEFAULT_BASE_URL = "https://3dfilamentprofiles.com"
 
@@ -248,6 +251,43 @@ def build_url(base_url: str, gcode_path: str) -> tuple[str | None, str]:
 
 
 DIALOG_TIMEOUT_SECONDS = 60
+# Longer than the dialog timeout: a slicer that runs the script again only after the
+# first run's dialog closes still lands inside the window.
+DEDUPE_WINDOW_SECONDS = 120
+
+
+def already_handled(url: str) -> bool:
+    """
+    True when this exact URL was already handled within DEDUPE_WINDOW_SECONDS. Some
+    slicers (Anycubic Slicer NEXT) run post-processing scripts several times for one
+    slice; keying on the URL rather than the gcode path catches that whatever temp file
+    each run is handed. A marker file per URL in the temp folder, created atomically,
+    lets exactly one run through even when the runs overlap. Any file-system trouble
+    means "not handled", so the worst case is the old behaviour: an extra dialog.
+    """
+    import glob
+    import hashlib
+    import tempfile
+    import time
+
+    try:
+        temp_dir = tempfile.gettempdir()
+        now = time.time()
+        for stale in glob.glob(os.path.join(temp_dir, "3dfp-print-log-*.seen")):
+            try:
+                if now - os.path.getmtime(stale) > DEDUPE_WINDOW_SECONDS:
+                    os.remove(stale)
+            except OSError:
+                pass
+        digest = hashlib.sha1(url.encode("utf-8")).hexdigest()[:16]
+        marker = os.path.join(temp_dir, f"3dfp-print-log-{digest}.seen")
+        try:
+            os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+            return False
+        except FileExistsError:
+            return True
+    except OSError:
+        return False
 
 
 def ask_user(summary: str) -> bool:
@@ -383,6 +423,10 @@ def main(argv: list[str]) -> int:
 
     if dry_run:
         print(url)
+        return 0
+
+    if already_handled(url):
+        print("3dfp-print-log: this print was already handled a moment ago, skipping.", file=sys.stderr)
         return 0
 
     if ask and not ask_user(summary):

--- a/tools/slicer-print-log/3dfp-print-log.py
+++ b/tools/slicer-print-log/3dfp-print-log.py
@@ -20,8 +20,8 @@ Skip and nothing happens. Pass --no-ask to always open the browser instead.
 Older Bambu Studio versions only ran them on File -> Export -> Export G-code
 (bambulab/BambuStudio#3006). OrcaSlicer runs them on export; if yours doesn't
 run them on Send, use Export G-code. Anycubic Slicer NEXT runs the script
-several times for one slice, so a slice that builds the same URL as one seen
-in the last DEDUPE_WINDOW_SECONDS is ignored (filament-profiles#644).
+several times for one slice, so a run that builds the same URL as one that
+finished less than DEDUPE_WINDOW_SECONDS ago is ignored (filament-profiles#644).
 
 What it does: takes the filament type/vendor/colour and printer from the
 SLIC3R_* environment variables the slicer sets, reads the .gcode header for
@@ -251,19 +251,21 @@ def build_url(base_url: str, gcode_path: str) -> tuple[str | None, str]:
 
 
 DIALOG_TIMEOUT_SECONDS = 60
-# Longer than the dialog timeout: a slicer that runs the script again only after the
-# first run's dialog closes still lands inside the window.
-DEDUPE_WINDOW_SECONDS = 120
+# Measured from the end of the previous run (see claim_marker), so it only has to cover
+# the gap between one run finishing and the slicer starting the next.
+DEDUPE_WINDOW_SECONDS = 10
 
 
-def already_handled(url: str) -> bool:
+def claim_marker(url: str) -> str | None:
     """
-    True when this exact URL was already handled within DEDUPE_WINDOW_SECONDS. Some
-    slicers (Anycubic Slicer NEXT) run post-processing scripts several times for one
-    slice; keying on the URL rather than the gcode path catches that whatever temp file
-    each run is handed. A marker file per URL in the temp folder, created atomically,
-    lets exactly one run through even when the runs overlap. Any file-system trouble
-    means "not handled", so the worst case is the old behaviour: an extra dialog.
+    Some slicers (Anycubic Slicer NEXT) run post-processing scripts several times for
+    one slice. A marker file per URL in the temp folder catches that whatever temp gcode
+    each run is handed: this returns None when a marker younger than DEDUPE_WINDOW_SECONDS
+    exists, otherwise the marker path (or "" when the temp folder is unusable, so the
+    worst case is the old behaviour: an extra dialog). The marker is created atomically,
+    so exactly one of several overlapping runs wins, and the caller refreshes it via
+    touch_marker when it is done, so a slicer that starts the next run only after the
+    first run's dialog closes still lands inside the window however long that took.
     """
     import glob
     import hashlib
@@ -283,11 +285,21 @@ def already_handled(url: str) -> bool:
         marker = os.path.join(temp_dir, f"3dfp-print-log-{digest}.seen")
         try:
             os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
-            return False
+            return marker
         except FileExistsError:
-            return True
+            return None
     except OSError:
-        return False
+        return ""
+
+
+def touch_marker(marker: str) -> None:
+    """Restarts the dedupe window from now, once the dialog and browser hand-off are done."""
+    if not marker:
+        return
+    try:
+        os.utime(marker, None)
+    except OSError:
+        pass
 
 
 def ask_user(summary: str) -> bool:
@@ -425,17 +437,21 @@ def main(argv: list[str]) -> int:
         print(url)
         return 0
 
-    if already_handled(url):
+    marker = claim_marker(url)
+    if marker is None:
         print("3dfp-print-log: this print was already handled a moment ago, skipping.", file=sys.stderr)
         return 0
 
-    if ask and not ask_user(summary):
-        return 0
-
     try:
-        webbrowser.open(url)
-    except Exception as err:  # never let a browser-launch failure break the slicer's export
-        print(f"3dfp-print-log: could not open browser: {err}", file=sys.stderr)
+        if ask and not ask_user(summary):
+            return 0
+
+        try:
+            webbrowser.open(url)
+        except Exception as err:  # never let a browser-launch failure break the slicer's export
+            print(f"3dfp-print-log: could not open browser: {err}", file=sys.stderr)
+    finally:
+        touch_marker(marker)
 
     return 0
 

--- a/tools/slicer-print-log/README.md
+++ b/tools/slicer-print-log/README.md
@@ -68,6 +68,7 @@ Options go after the script path on the same line, for example `"python3" "3dfp-
 - **Older Bambu Studio** only ran them on File, Export, Export G-code, not on Send or on the sliced .3mf export.
 - **OrcaSlicer** runs them on export; some versions don't run them on Send. If nothing happens on Send, use Export G-code.
 - **PrusaSlicer** runs them on export.
+- **Anycubic Slicer NEXT** runs them several times for one slice. The script notices and only asks once: a repeat run that builds the same URL within two minutes is skipped.
 
 ## What gets sent
 

--- a/tools/slicer-print-log/README.md
+++ b/tools/slicer-print-log/README.md
@@ -68,7 +68,7 @@ Options go after the script path on the same line, for example `"python3" "3dfp-
 - **Older Bambu Studio** only ran them on File, Export, Export G-code, not on Send or on the sliced .3mf export.
 - **OrcaSlicer** runs them on export; some versions don't run them on Send. If nothing happens on Send, use Export G-code.
 - **PrusaSlicer** runs them on export.
-- **Anycubic Slicer NEXT** runs them several times for one slice. The script notices and only asks once: a repeat run that builds the same URL within two minutes is skipped.
+- **Anycubic Slicer NEXT** runs them several times for one slice. The script notices and only asks once: a repeat run that builds the same URL within ten seconds of the previous one finishing is skipped.
 
 ## What gets sent
 


### PR DESCRIPTION
Fixes #644.

Anycubic Slicer NEXT runs post-processing scripts several times for one slice, so the "Log this print?" dialog opened about three times per print. OrcaSlicer runs the same script once, as confirmed on the issue.

Both scripts (now 1.1.0) build the URL as before, then create a marker file keyed on that URL in the system temp folder using an atomic create-new. A repeat run that finds a marker younger than ten seconds skips with a note on stderr. The marker is refreshed when a run finishes, so the ten seconds only has to cover the gap between one run ending and the slicer starting the next, however long the dialog was open. Markers older than that are swept on each run. `--dry-run` is unaffected, and any file-system error falls back to the old behaviour.

README gains a line under "When does it run?".

Tested on macOS with Python 3.14: sequential, overlapping, and slow-then-immediate repeat runs open the browser once. The PowerShell script carries the same change but has not been run on Windows yet.
